### PR TITLE
Roll dialog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.idea/
+*.code-workspace
+.history

--- a/module/FBLActor.js
+++ b/module/FBLActor.js
@@ -5,11 +5,12 @@ import { CONFIG_WEAR_ICONS,
     CONFIG_DICE_ICONS,
     CONFIG_MONEY } from "./Config.js";
 
-    import { fblPool,
-        prepareRollData,
-        prepareChatData } from "./helper-functions.js";
+import { fblPool,
+    prepareRollData,
+    prepareChatData } from "./helper-functions.js";
 
-    import { FBLChatMessage } from "./FBLRollMessage.js"
+import { FBLChatMessage } from "./FBLRollMessage.js"
+import { RollDialog } from "./FBLRollDialog.js";
 
 export class FBLActor extends Actor {
     
@@ -197,22 +198,17 @@ async rollCheck(rollType, id) {
     if (!rollData) return;
     // console.log(rollData);
 
-    const displayData = rollData;
-  
-    // roll the check
-    let rollCheck = new fblPool(rollData.attributeDice, rollData.skillDice, rollData.gearDice, rollData.artifactDie);
-    // console.log(rollCheck);
-  
-    let chatData = await prepareChatData(rollCheck, rollType, displayData);
-    // console.log(chatData);
-
-    chatData.speaker = {actor: actor._id,
-                        token: actor.token,
-                        alias: actor.name};
-  
-    // console.log(chatData);
-    let msg = await FBLChatMessage.create(chatData, {}, rollCheck);
-    // console.log(msg);
+    RollDialog.show(
+        {
+            rollingActor:actor,
+            rollName: id,
+            baseDice: { name: game.i18n.localize(rollData.attributeName ?? 'Base'), value: rollData.attributeDice },
+            skillDice: { name: game.i18n.localize(rollData.skillName ?? 'Skill'), value: rollData.skillDice },
+            gearDice: { name: game.i18n.localize(rollData.itemName ?? 'Gear'), value: rollData.gearDice },
+            artifactDice: null,
+            modifier: 0,
+        }
+    );
   }
   //------------------------------------------------------------------------------------------------
 

--- a/module/FBLActorSheet.js
+++ b/module/FBLActorSheet.js
@@ -265,7 +265,7 @@ export class PlayerCharacterSheet extends FBLActorSheet {
     // Listener to manage item-related operations: delete, consumables increase or decrese, etc.
     this.form.addEventListener("click", updateTrackData.bind(this));
     this.form.addEventListener("dblclick", itemEvents.bind(this));
-    this.form.addEventListener("dblclick", rollCheckHandler.bind(this));
+    this.form.addEventListener("click", rollCheckHandler.bind(this));
     this.form.addEventListener("dblclick", rollConsumable.bind(this));
     this.form.addEventListener("dblclick", woundTreatment.bind(this));
     this.form.addEventListener("dblclick", showItemSheet.bind(this));

--- a/module/FBLRollDialog.js
+++ b/module/FBLRollDialog.js
@@ -74,10 +74,11 @@ export class RollDialog extends Dialog {
           let skill = html.find('.input-skill')[0].value;
           let gear = html.find('.input-gear')[0].value;
           let modifier = Number(html.find('.modifier')[0].innerHTML);
-          let nArtifact = [];
-          if (html.find('.input-artifact-8')[0].value > 0) nArtifact.push('d8');
-          if (html.find('.input-artifact-10')[0].value > 0) nArtifact.push('d10');
-          if (html.find('.input-artifact-12')[0].value > 0) nArtifact.push('d12');
+          let nArtifact = [].concat(
+            new Array(html.find('.input-artifact-8')[0].value).fill('d8'),
+            new Array(html.find('.input-artifact-10')[0].value).fill('d10'),
+            new Array(html.find('.input-artifact-12')[0].value).fill('d12'),
+          );
 
           const newRoll = new fblPool(Number(base), Number(skill) + modifier, Number(gear), nArtifact);
           const displayData = {

--- a/module/FBLRollDialog.js
+++ b/module/FBLRollDialog.js
@@ -1,0 +1,133 @@
+import { fblPool, prepareChatData } from "./helper-functions.js"
+import { FBLChatMessage } from "./FBLRollMessage.js"
+
+/**
+ * Extension of the Dialog class that allows making a generic roll.
+ */
+export class RollDialog extends Dialog {
+
+  constructor(dialogData, options) {
+    super(dialogData, options);
+
+    this.actor    = dialogData.actor;
+    this.rollName = dialogData.rollName;
+    this.base = dialogData.baseDice ?? { name: 'Base', value: 0};
+    this.skill = dialogData.skillName ?? { name: 'Skill', value: 0};
+    this.gear = dialogData.gearName ?? { name: 'Gear', value: 0};
+    this.artifactDice = dialogData.artifactDice ?? [];
+    this.modifier = dialogData.modifier ?? 0;
+
+    this.onRoll = dialogData.onRoll ?? (() => {});
+    this.onCancel = dialogData.onCancel ?? (() => {});
+
+    this.canPush = dialogData.canPush ?? true;
+  }
+
+  static get defaultOptions() {
+    return mergeObject(super.defaultOptions, {
+      classes: ["fbl"],
+      template: "/systems/forbiddenlands/templates/roll-dialog.html"
+    })
+  };
+
+  getData() {
+    let data = this.data;
+
+    // override buttons
+    data.buttons = this.getButtons();
+    data.base = this.base;
+    data.skill = this.skill;
+    data.gear = this.gear;
+    data.artifactDice = this.artifactDice;
+    data.modifier = (this.modifier >= 0 ? '+' : '') + this.modifier;
+
+    return data;
+  }
+
+  activateListeners(html) {
+    super.activateListeners(html);
+  }
+
+  getButtons() {
+    return {
+      cancel: {
+        icon: '<i class="fas fa-times"></i>',
+        label: "Cancel",
+        callback: this.onCancel
+      },
+      roll: {
+        icon: '<i class="fas fa-check"></i>',
+        label: "Roll",
+        callback: (html) => {
+          let base = html.find('.input-base')[0].value;
+          let skill = html.find('.input-skill')[0].value;
+          let gear = html.find('.input-gear')[0].value;
+          let nArtifact = [];
+
+          const newRoll = new fblPool(Number(base), Number(skill), Number(gear), nArtifact);
+          const displayData = {
+            canPush: this.canPush, 
+            canPride: true,
+            attributeName: this.base.name,
+            skillName: this.skill.name,
+            itemName: this.gear.name,
+            description: this.rollName,
+          };
+          prepareChatData(newRoll, undefined, displayData).then( async chatData => {
+            chatData.speaker = {actor: this.actor};
+            await FBLChatMessage.create(chatData, {}, newRoll);
+          });
+
+          this.onRoll(newRoll);
+        } 
+      },
+    }
+  }
+
+  /**
+   * A helper factory method to create a roll dialog.
+   *
+   * @param {Actor} rollingActor    Actor that makes the roll
+   * @param {string} rollName       Name of the roll (e.g. skill name or custom string like "Hunt Prey")
+   * @param {object} baseDice       {name: "Base": value: 0}
+   * @param {object} skillDice      {name: "Skill": value: 0}
+   * @param {object} gearDice       {name: "Gear": value: 0}
+   * @param {Array} artifactDice    Array of artifact dice. E.g. [8, 10, 12].
+   * @param {number} modifier       Skill dice modifier
+   * 
+   * @param {Function} onRoll       Callback function upon Roll
+   * @param {Function} onCancel     Callback function upon Cancel
+   * 
+   * @param {boolean} canPush       Whether roll can be pushed
+   *
+   * @return {Promise}              A promise which resolves once the user makes a choice or closes the window
+   */
+  static async show(
+    {rollingActor, rollName, baseDice, skillDice, gearDice, artifactDice, modifier}, 
+    {onRoll, onCancel}={}, 
+    canPush = true
+  ) {
+    return new Promise(resolve => {
+      const dialog = new this({
+        actor: rollingActor,
+        rollName: rollName,
+        baseDice: baseDice,
+        skillDice: skillDice,
+        gearDice: gearDice,
+        artifactDice: artifactDice,
+        modifier: modifier,
+
+        onRoll: onRoll,
+        onCancel: onCancel,
+
+        canPush: canPush,
+
+        title: 'Roll: ' + rollName,
+        default: "roll",
+        close: resolve
+      });
+      
+      dialog.render(true);
+    });
+  }
+}

--- a/module/FBLRollDialog.js
+++ b/module/FBLRollDialog.js
@@ -74,11 +74,14 @@ export class RollDialog extends Dialog {
           let skill = html.find('.input-skill')[0].value;
           let gear = html.find('.input-gear')[0].value;
           let modifier = Number(html.find('.modifier')[0].innerHTML);
-          let nArtifact = [].concat(
-            new Array(html.find('.input-artifact-8')[0].value).fill('d8'),
-            new Array(html.find('.input-artifact-10')[0].value).fill('d10'),
-            new Array(html.find('.input-artifact-12')[0].value).fill('d12'),
-          );
+          let d8 = Number(html.find('.input-artifact-8')[0].value);
+          let d10 = Number(html.find('.input-artifact-10')[0].value);
+          let d12 = Number(html.find('.input-artifact-12')[0].value);
+          let nArtifact = [];
+          if (d8 > 0) nArtifact.push(new Array(d8).fill('d8'));
+          if (d10 > 0) nArtifact.push(new Array(d10).fill('d10'));
+          if (d12 > 0) nArtifact.push(new Array(d12).fill('d12'));
+          nArtifact = [].concat(...nArtifact);
 
           const newRoll = new fblPool(Number(base), Number(skill) + modifier, Number(gear), nArtifact);
           const displayData = {
@@ -87,7 +90,6 @@ export class RollDialog extends Dialog {
             attributeName: this.base.name,
             skillName: this.skill.name,
             itemName: this.gear.name,
-            description: this.rollName,
           };
           prepareChatData(newRoll, undefined, displayData).then( async chatData => {
             chatData.speaker = {actor: this.actor};

--- a/module/FBLRollDialog.js
+++ b/module/FBLRollDialog.js
@@ -73,12 +73,13 @@ export class RollDialog extends Dialog {
           let base = html.find('.input-base')[0].value;
           let skill = html.find('.input-skill')[0].value;
           let gear = html.find('.input-gear')[0].value;
+          let modifier = Number(html.find('.modifier')[0].innerHTML);
           let nArtifact = [];
           if (html.find('.input-artifact-8')[0].value > 0) nArtifact.push('d8');
           if (html.find('.input-artifact-10')[0].value > 0) nArtifact.push('d10');
           if (html.find('.input-artifact-12')[0].value > 0) nArtifact.push('d12');
 
-          const newRoll = new fblPool(Number(base), Number(skill), Number(gear), nArtifact);
+          const newRoll = new fblPool(Number(base), Number(skill) + modifier, Number(gear), nArtifact);
           const displayData = {
             canPush: this.canPush, 
             canPride: true,

--- a/styles/fbl.css
+++ b/styles/fbl.css
@@ -803,11 +803,13 @@ input[type="text"].table__data--fill-form {
 .fbl .tabs .item, .fbl .equipmentTabs .item {
   text-shadow: none;
   background-color: rgba(0,0,0,0.1);
+  color: gray;
 }
 
 .fbl .tabs .item.active, .fbl .equipmentTabs .item.active {
   text-shadow: none;
   background-color: var(--title-background-color);
+  color: white;
 }
 
 .trackedResource {

--- a/styles/roll-dialog.css
+++ b/styles/roll-dialog.css
@@ -6,6 +6,14 @@
     display: inline-flex;
 }
 
+.roll-dialog li:before {
+    content: none;
+}
+
+.roll-dialog ol {
+    padding: 0 0 0 0;
+}
+
 .roll-dialog .input-label {
     width: 120px;
     display: inline-flex;

--- a/styles/roll-dialog.css
+++ b/styles/roll-dialog.css
@@ -1,0 +1,61 @@
+.app.window-app.fbl.roll-dialog {
+    max-width: none;
+}
+
+.roll-dialog .input-label {
+    width: 120px;
+    display: inline-flex;
+    height: 40px;
+    font-size: 14px;
+    justify-content: flex-end;
+    align-items: center;
+}
+
+.roll-dialog .input-dice {
+    width: 60px;
+    text-align: center;
+    font-size: 30px;
+    vertical-align: top;
+}
+
+.roll-dialog .modifier {
+    font-size: 30px;
+    font-family: Arial;
+    width: 35px;
+    height: 40px;
+    display: inline-flex;
+    align-items: center;
+}
+
+.roll-dialog .step-buttons {
+    display: inline-flex;
+    flex-direction: column;
+    vertical-align: top;
+}
+
+.roll-dialog .step-button {
+    line-height: normal;
+    font-size: 13px;
+}
+
+.roll-dialog .dialog-buttons {
+    display: flex;
+    flex: none;
+}
+
+.roll-dialog .artifact-dice {
+    margin-top: 8px;
+    margin-bottom: 8px;
+}
+
+.roll-dialog .artifact-die {
+    width: 30px;
+    height: 30px;
+    vertical-align: top;
+}
+
+.roll-dialog .artifact-dice .input-dice {
+    font-size: 21px;
+    width: 50px;
+    margin-right: 2px;
+}

--- a/styles/roll-dialog.css
+++ b/styles/roll-dialog.css
@@ -2,6 +2,10 @@
     max-width: none;
 }
 
+.roll-dialog .row {
+    display: inline-flex;
+}
+
 .roll-dialog .input-label {
     width: 120px;
     display: inline-flex;
@@ -9,6 +13,7 @@
     font-size: 14px;
     justify-content: flex-end;
     align-items: center;
+    margin-right: 6px;
 }
 
 .roll-dialog .input-dice {

--- a/system.json
+++ b/system.json
@@ -7,7 +7,7 @@
     "minimumCoreVersion": "0.6.5",
     "compatibleCoreVersion": "0.6.5",
     "author": "Leonardo",
-    "styles": ["styles/fbl.css"],
+    "styles": ["styles/fbl.css", "styles/roll-dialog.css"],
     "esmodules": ["module/fbl.js", "module/helper-functions.js"],
     "socket": true,
     "url":"https://github.com/LeonardoFacchin/Foundry-VTT-Forbidden-Lands-System",

--- a/templates/roll-dialog.html
+++ b/templates/roll-dialog.html
@@ -1,23 +1,30 @@
 <div class="dialog-content">
     <div>
-        <span>{{ localize base.name }}</span> 
-        <input class="input-dice input-base" type="number" min="0" step="1" value="{{ base.value }}" />
+        <span class="input-label">{{ localize base.name }}</span> 
+        <input class="input-dice input-base" type="number" min="0" step="1" value="{{ base.value }}" data-dice="base" />
     </div>
     <div>
-        <span>{{ localize skill.name }}</span> 
-        <input class="input-dice input-skill" type="number" min="0" step="1" value="{{ skill.value }}" />
-        <span>{{ modifier }}</span>
-        <div>
-            <button class="button modifier-plus">+</button>
-            <button class="button modifier-minus">-</button>
+        <span class="input-label">{{ localize skill.name }}</span> 
+        <input class="input-dice input-skill" type="number" min="0" step="1" value="{{ skill.value }}" data-dice="skill" />
+        <span class="modifier">{{ modifier }}</span>
+        <div class="step-buttons">
+            <button class="step-button modifier-plus">+</button>
+            <button class="step-button modifier-minus">-</button>
         </div>
     </div>
     <div>
-        <span>{{ localize gear.name }}</span> 
-        <input class="input-dice input-gear" type="number" min="0" step="1" value="{{ gear.value }}" />
+        <span class="input-label">{{ localize gear.name }}</span> 
+        <input class="input-dice input-gear" type="number" min="0" step="1" value="{{ gear.value }}" data-dice="gear" />
     </div>
-    <div>
-        artifact
+    <div class="artifact-dice">
+        <img class="artifact-die" src="systems/forbiddenlands/icons/dice/d8black.svg" alt="d8">
+        <input class="input-dice input-artifact input-artifact-8" type="number" min="0" max="1" step="1" value="{{ artifact.d8 }}" data-dice="artifact.d8" />
+        
+        <img class="artifact-die" src="systems/forbiddenlands/icons/dice/d10black.svg" alt="d10">
+        <input class="input-dice input-artifact input-artifact-10" type="number" min="0" max="1" step="1" value="{{ artifact.d10 }}" data-dice="artifact.d10" />
+        
+        <img class="artifact-die" src="systems/forbiddenlands/icons/dice/d12black.svg" alt="d12">
+        <input class="input-dice input-artifact input-artifact-12" type="number" min="0" max="1" step="1" value="{{ artifact.d12 }}" data-dice="artifact.d12" />
     </div>
 </div>
 <div class="dialog-buttons">

--- a/templates/roll-dialog.html
+++ b/templates/roll-dialog.html
@@ -1,9 +1,9 @@
 <div class="dialog-content">
-    <div>
+    <div class="row">
         <span class="input-label">{{ localize base.name }}</span> 
         <input class="input-dice input-base" type="number" min="0" step="1" value="{{ base.value }}" data-dice="base" />
     </div>
-    <div>
+    <div class="row">
         <span class="input-label">{{ localize skill.name }}</span> 
         <input class="input-dice input-skill" type="number" min="0" step="1" value="{{ skill.value }}" data-dice="skill" />
         <span class="modifier">{{ modifier }}</span>
@@ -12,7 +12,7 @@
             <button class="step-button modifier-minus">-</button>
         </div>
     </div>
-    <div>
+    <div class="row">
         <span class="input-label">{{ localize gear.name }}</span> 
         <input class="input-dice input-gear" type="number" min="0" step="1" value="{{ gear.value }}" data-dice="gear" />
     </div>

--- a/templates/roll-dialog.html
+++ b/templates/roll-dialog.html
@@ -18,13 +18,13 @@
     </div>
     <div class="artifact-dice">
         <img class="artifact-die" src="systems/forbiddenlands/icons/dice/d8black.svg" alt="d8">
-        <input class="input-dice input-artifact input-artifact-8" type="number" min="0" max="1" step="1" value="{{ artifact.d8 }}" data-dice="artifact.d8" />
+        <input class="input-dice input-artifact input-artifact-8" type="number" min="0" max="3" step="1" value="{{ artifact.d8 }}" data-dice="artifact.d8" />
         
         <img class="artifact-die" src="systems/forbiddenlands/icons/dice/d10black.svg" alt="d10">
-        <input class="input-dice input-artifact input-artifact-10" type="number" min="0" max="1" step="1" value="{{ artifact.d10 }}" data-dice="artifact.d10" />
+        <input class="input-dice input-artifact input-artifact-10" type="number" min="0" max="3" step="1" value="{{ artifact.d10 }}" data-dice="artifact.d10" />
         
         <img class="artifact-die" src="systems/forbiddenlands/icons/dice/d12black.svg" alt="d12">
-        <input class="input-dice input-artifact input-artifact-12" type="number" min="0" max="1" step="1" value="{{ artifact.d12 }}" data-dice="artifact.d12" />
+        <input class="input-dice input-artifact input-artifact-12" type="number" min="0" max="3" step="1" value="{{ artifact.d12 }}" data-dice="artifact.d12" />
     </div>
 </div>
 <div class="dialog-buttons">

--- a/templates/roll-dialog.html
+++ b/templates/roll-dialog.html
@@ -1,0 +1,30 @@
+<div class="dialog-content">
+    <div>
+        <span>{{ localize base.name }}</span> 
+        <input class="input-dice input-base" type="number" min="0" step="1" value="{{ base.value }}" />
+    </div>
+    <div>
+        <span>{{ localize skill.name }}</span> 
+        <input class="input-dice input-skill" type="number" min="0" step="1" value="{{ skill.value }}" />
+        <span>{{ modifier }}</span>
+        <div>
+            <button class="button modifier-plus">+</button>
+            <button class="button modifier-minus">-</button>
+        </div>
+    </div>
+    <div>
+        <span>{{ localize gear.name }}</span> 
+        <input class="input-dice input-gear" type="number" min="0" step="1" value="{{ gear.value }}" />
+    </div>
+    <div>
+        artifact
+    </div>
+</div>
+<div class="dialog-buttons">
+    {{#each buttons as |button id|}}
+    <button class="dialog-button" data-button="{{id}}">
+        {{{button.icon}}}
+        {{{ localize button.label}}}
+    </button>
+    {{/each}}
+</div>


### PR DESCRIPTION
Hello.
I propose to change how rolls are invoked.
Right now you have to click an applicable modifier and then double-click the skill for example. I feel that this workflow is error prone. E.g. player forgot to unclick a modifier and rolled a skill check.
My solution to that is to show a roll dialog window instead of immediately doing the roll (similar to what you did with spell rolls).
![image](https://user-images.githubusercontent.com/12498023/92335829-7ca8e380-f0a3-11ea-8832-0c51fb0d7618.png)
This will allow player to re-check that everything is in order before he rolls. That will also allow to get rid of modifier/artifact dice sections at the bottom right of the char sheet, freeing up more space for other stuff. E.g. conditions and/or injuries could be moved there and talent section expanded.